### PR TITLE
Add initial openapi specification and docs path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ orbs:
 workflows:
   build:
     jobs:
+      - ruby-rails/validate-api:
+          name: validate
       - ruby-rails/lint:
           name: lint
           executor:

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ gem "rails", "~> 7.0.4", ">= 7.0.4.3"
 # The original asset pipeline for Rails [https://github.com/rails/sprockets-rails]
 gem "sprockets-rails"
 
+gem "okcomputer"
+
 # Use postgresql as the database for Active Record
 gem "pg", "~> 1.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,9 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.2-x86_64-linux)
+      racc (~> 1.4)
+    okcomputer (1.18.4)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
@@ -241,7 +244,6 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
-  ruby
   x86_64-darwin-21
   x86_64-linux
 
@@ -250,6 +252,7 @@ DEPENDENCIES
   byebug
   importmap-rails
   jbuilder
+  okcomputer
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,86 +1,21 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  username: "<%= ENV.fetch('DATABASE_USERNAME', 'postgres') %>"
+  password: "<%= ENV.fetch('DATABASE_PASSWORD', 'postgres') %>"
+  host: "<%= ENV.fetch('DATABASE_HOSTNAME', 'localhost') %>"
+  port: "<%= ENV.fetch('DATABASE_PORT', 5432) %>"
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
 
 development:
   <<: *default
-  database: dataloading_management_development
+  database: "<%= ENV.fetch('DATABASE_NAME', 'dlm_development') %>"
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: dataloading_management
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: dataloading_management_test
+  database: "<%= ENV.fetch('DATABASE_NAME', 'dlm_test') %>"
 
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["MY_APP_DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
 production:
   <<: *default
-  database: dataloading_management_production
-  username: dataloading_management
-  password: <%= ENV["DATALOADING_MANAGEMENT_DATABASE_PASSWORD"] %>
+  database: "<%= ENV.fetch('DATABASE_NAME', 'dlm_production') %>"

--- a/config/initializers/okcomputer.rb
+++ b/config/initializers/okcomputer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+OkComputer.mount_at = "status"
+OkComputer.check_in_parallel = true
+
+# Required
+OkComputer::Registry.register "ruby_version", OkComputer::RubyVersionCheck.new

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.6'
+
+services:
+  db:
+    image: postgres:14
+    environment:
+      POSTGRES_DB: dlm_development
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - 5432:5432
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+volumes:
+  postgres-data:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>API documentation</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='https://raw.githubusercontent.com/sul-dlss/dataloading-management/main/openapi.yml'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-alpha.17/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,0 +1,93 @@
+openapi: 3.0.0
+info:
+  description: '[DRAFT] Backend API for Folio data loading management'
+  version: 1.0.0
+  title: Folio Data Loading Management API
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+paths:
+  /v1/about:
+    get:
+      summary: A healthcheck endpoint
+      responses:
+        '200':
+          description: The status of the service
+  /v1/job:
+    get:
+      summary: Retrieve the list of scheduled data loading jobs
+      description: ''
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DataLoadJobsResponse'
+  '/v1/job/{id}':
+    post:
+      summary: Post job status to management application
+      responses:
+        '202':
+          description: Accepted
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/UUID'
+      requestBody:
+        description: Data payload for job status
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DataLoadJobResult'
+components:
+  schemas:
+    DataLoadJob:
+      description: Information used to schedule a data load job in the pipeline
+      type: object
+      additionalProperties: false
+      properties:
+        organizationId:
+          $ref: '#/components/schemas/UUID'
+        dataLoadProfile:
+          type: string
+        dataProcessingSteps:
+          type: array
+          items:
+            type: string
+        filename:
+          type: string
+      required:
+        - organizationId
+        - dataLoadProfile
+    DataLoadJobsResponse:
+      description: List of jobs to be scheduled
+      type: object
+      additionalProperties: false
+      properties:
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DataLoadJob'
+    DataLoadJobResult:
+      description: Statistics and results of a data load job
+      type: object
+      additionalProperties: false
+      properties:
+        organizationId:
+          $ref: '#/components/schemas/UUID'
+        dagRunId:
+          $ref: '#/components/schemas/UUID'
+        filename:
+          type: string
+        status:
+          type: string
+    UUID:
+      type: string
+      pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      # the regex above limits the length;
+      # however, some tools might require explicit settings:
+      minLength: 36
+      maxLength: 36

--- a/openapi.yml
+++ b/openapi.yml
@@ -7,13 +7,13 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
 paths:
-  /v1/about:
+  /v1/status:
     get:
       summary: A healthcheck endpoint
       responses:
         '200':
           description: The status of the service
-  /v1/job:
+  /v1/dataloads:
     get:
       summary: Retrieve the list of scheduled data loading jobs
       description: ''
@@ -24,7 +24,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DataLoadJobsResponse'
-  '/v1/job/{id}':
+  '/v1/dataloads/{id}':
     post:
       summary: Post job status to management application
       responses:

--- a/openapi.yml
+++ b/openapi.yml
@@ -16,7 +16,7 @@ paths:
   /v1/dataloads:
     get:
       summary: Retrieve the list of scheduled data loading jobs
-      description: ''
+      description: Provide a list of jobs to run since the last request
       responses:
         '200':
           description: OK
@@ -59,6 +59,14 @@ components:
             type: string
         filename:
           type: string
+        user:
+          type: string
+          description: The sunetid of the scheduling user
+        notifyList:
+          type: array
+          items:
+            type: string
+          description: An array of email addresses to include in any notifications.
       required:
         - organizationId
         - dataLoadProfile


### PR DESCRIPTION
This is an initial pass at the simple API spec, mostly to get the validation into the build process. This required a basic database configuration as well to start the local application and verify the status check endpoint.