### PR TITLE
Remove hard-coded Ruby version from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.1.2"
-
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem "rails", "~> 7.0.4", ">= 7.0.4.3"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,8 +286,5 @@ DEPENDENCIES
   tzinfo-data
   web-console
 
-RUBY VERSION
-   ruby 3.1.2p20
-
 BUNDLED WITH
    2.4.6


### PR DESCRIPTION
We considered doing this last year or so and decided not to move forward with using the Gemfile to manage ruby versions.
