### PR TITLE
Add initial page layout for display

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,16 +1,35 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <title>DataloadingManagement</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>SUL - Vendor Dataloading Management</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
 
   <body>
-    <%= yield %>
+    <div class="container">
+      <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <%= link_to "SUL - Vendor Dataloading Management", root_path, class: 'navbar-brand' %>
+        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavAltMarkup" aria-controls="navbarNavAltMarkup" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
+          <div class="navbar-nav">
+            <a class="nav-item nav-link " href="">Status</a>
+          </div>
+          <div class="navbar-nav">
+            <a class="nav-item nav-link " href="">Vendors</a>
+          </div>
+          <div class="navbar-nav">
+            <a class="nav-item nav-link " href="">Schedule</a>
+          </div>
+        </div>
+      </nav>
+
+      <%= yield %>
+
+    </div>
   </body>
 </html>

--- a/spec/request/homepage_spec.rb
+++ b/spec/request/homepage_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe "Data Loading Management", type: :request do
   context "when visiting the homepage" do
     it "responds with success" do
       get "/"
-      expect(response).to be_successful
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match(/Data Loading Management Statistics/)
+      expect(response.body).to match(/Status/)
+      expect(response.body).to match(/Vendors/)
+      expect(response.body).to match(/Schedule/)
     end
   end
 end


### PR DESCRIPTION
This is basically a simple copy of the same layout we use in Google Books. This will be used to setup our simple navigation and wireframes for pages to be added.

![Screenshot 2023-03-30 at 3 23 54 PM](https://user-images.githubusercontent.com/2294288/228977155-6eb6dd20-d1f8-45b2-94a1-22fd5b4c765b.png)
