### PR TITLE
rescue folio_client config errors and give nice message

### DIFF
--- a/config/initializers/folio_client.rb
+++ b/config/initializers/folio_client.rb
@@ -1,14 +1,24 @@
 # frozen_string_literal: true
 
-if !Rails.env.test?
-  FolioClient.configure(
-    url: Settings.folio.url,
-    login_params: {
-      username: Settings.folio.username, password: Settings.folio.password
-    },
-    okapi_headers: {
-      "X-Okapi-Tenant": Settings.folio.tenant_id,
-      "User-Agent": "folio_client #{FolioClient::VERSION}; dataloading-management #{Rails.env}"
-    }
-  )
+# Configure folio_client singleton
+begin
+  if !Rails.env.test?
+    FolioClient.configure(
+      url: Settings.folio.url,
+      login_params: {
+        username: Settings.folio.username, password: Settings.folio.password
+      },
+      okapi_headers: {
+        "X-Okapi-Tenant": Settings.folio.tenant_id,
+        "User-Agent": "folio_client #{FolioClient::VERSION}; dataloading-management #{Rails.env}"
+      }
+    )
+  end
+rescue FolioClient::Error => e
+  # as of v0.1.0, folio_client tries to connect immediately upon configuration, which would
+  # prevent running tests or rails console on laptop.  would also prevent deployment or startup
+  # of dor-services-app if configuration was incorrect (missing settings, stale password, etc).
+  helpful_message = "You can avoid this by using RAILS_ENV=test"
+  Rails.logger.warn("Error configuring FolioClient: #{e} - #{helpful_message}}")
+  Honeybadger.notify(e, context: {helpful_message: helpful_message})
 end


### PR DESCRIPTION
# Why was this change made? 🤔

Because it's a good idea to give useful error messages -- except now the developer would need to know to look in the rails logs.  Suggestions?

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

