### PR TITLE
Increase consistency w/in FolioClient configuration

### DIFF
--- a/config/initializers/folio_client.rb
+++ b/config/initializers/folio_client.rb
@@ -1,4 +1,5 @@
-if !Rails.env.test?
+# Configure folio_client singleton
+begin
   FolioClient.configure(
     url: Settings.folio.url,
     login_params: {
@@ -9,4 +10,10 @@ if !Rails.env.test?
       "User-Agent": "folio_client #{FolioClient::VERSION}; dataloading-management #{Rails.env}"
     }
   )
+rescue => e
+  # folio_client tries to connect immediately upon configuration, which would
+  # prevent running tests or rails console on laptop.  would also prevent deployment or startup
+  # of the app if configuration was incorrect (missing settings, stale password, etc).
+  Rails.logger.warn("Error configuring FolioClient: #{e}")
+  Honeybadger.notify(e) if defined?(Honeybadger)
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,6 @@
 host: "localhost:3000"
 folio:
   url: "https://okapi-dev.example.com"
-  username: "app_sdr"
+  username: "app_libsys"
   password: "supersecret"
   tenant_id: "example_tenant"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,5 +2,5 @@ host: "localhost:3000"
 folio:
   url: "https://okapi-dev.example.com"
   username: "app_libsys"
-  password: "supersecret"
+  password: "supersecret" # vault kv get puppet/application/folio/app_libsys_password
   tenant_id: "example_tenant"


### PR DESCRIPTION
Supersedes #52 

# Why was this change made? 🤔

- Configure FolioClient using begin/rescue instead of env-sniffing
- Fix default Folio username
- Document where developers should get vault password

# How was this change tested? 🤨

CI
