### PR TITLE
Start fleshing out vendor index view

### DIFF
--- a/.rubocop/custom.yml
+++ b/.rubocop/custom.yml
@@ -21,6 +21,7 @@ RSpec/MultipleExpectations:
   Max: 5 # default 1
   Exclude:
     - 'spec/features/**/*_spec.rb'
+    - 'spec/requests/**/*_spec.rb'
 RSpec/MultipleMemoizedHelpers:
   Enabled: false
 RSpec/NestedGroups:

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -1,9 +1,29 @@
 <h1>Vendors</h1>
 
 <div id="vendors">
-  <% @vendors.each do |vendor| %>
-    <p>
-      <%= link_to vendor.folio_id, vendor_url(vendor.folio_id) %>
-    </p>
-  <% end %>
+  <table class="table table-striped">
+    <thead>
+      <tr>
+        <th class="col-4">Vendor</th>
+        <th class="col-1">Folio's Vendor Status</th>
+        <th class="col-2">Last Scheduled Job</th>
+        <th class="col-2">Can any info like next scheduled job or job freq go here?</th>
+        <th class="col-1">(Action Buttons)</th>
+      </tr>
+    </thead>
+    <tbody>
+    <% @vendors.each do |vendor| %>
+      <tr>
+        <td>
+          <%= link_to vendor.name, vendor_url(vendor.folio_id) %><br/>
+          ID: <%= vendor.folio_id %>
+        </td>
+        <td>Active?</td>
+        <td>Get Last Scheduled Job from ???</td>
+        <td>Get Next Scheduled Job from dataload job model</td>
+        <td>vendor's active buttons</td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
 </div>

--- a/spec/requests/vendors_spec.rb
+++ b/spec/requests/vendors_spec.rb
@@ -1,7 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "/vendors" do
-  let!(:vendor) { create(:vendor) }
+  let!(:vendor1) { create(:vendor) }
+  let!(:vendor2) { create(:vendor) }
 
   before { sign_in(create(:user)) }
 
@@ -9,17 +10,27 @@ RSpec.describe "/vendors" do
     it "renders a list of vendors" do
       get "/vendors"
       expect(response).to be_successful
-      expect(response.body).to include(vendor.folio_id)
-      expect(response.body).not_to include(vendor.folio_code)
+      body = response.body
+
+      expect(body).to include("Folio's Vendor Status</th>")
+      expect(body).to include("Last Scheduled Job</th>")
+
+      expect(body).to include("/vendors/#{vendor1.folio_id}\">#{vendor1.name}</a>")
+      expect(body).to include("ID: #{vendor1.folio_id}")
+      expect(body).not_to include(vendor1.folio_code)
+
+      expect(body).to include("/vendors/#{vendor2.folio_id}\">#{vendor2.name}</a>")
+      expect(body).to include("ID: #{vendor2.folio_id}")
+      expect(body).not_to include(vendor2.folio_code)
     end
   end
 
   describe "GET /vendor/{folio_id}" do
     it "renders vendor display" do
-      get "/vendors/#{vendor.folio_id}"
+      get "/vendors/#{vendor2.folio_id}"
       expect(response).to be_successful
-      expect(response.body).to include(vendor.folio_id)
-      expect(response.body).to include(vendor.folio_code)
+      expect(response.body).to include(vendor2.folio_id)
+      expect(response.body).to include(vendor2.folio_code)
     end
 
     it "raises ActiveRecord::RecordNotFound when vendor doesn't exist" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,7 +80,7 @@ RSpec.configure do |config|
   # Print the 10 slowest examples and example groups at the
   # end of the spec run, to help surface which specs are running
   # particularly slow.
-  config.profile_examples = 10 unless config.files_to_run.one?
+  # config.profile_examples = 10 unless config.files_to_run.one?
 
   # Run specs in random order to surface order dependencies. If you find an
   # order dependency and want to debug it, you can fix the order by providing


### PR DESCRIPTION
# Why was this change made? 🤔

part of #40.  

Puts the information we have so far into the vendor index view, with the bootstrap formatting for what we have so far.

Here's where this PR gets us:

## After these changes

![image](https://user-images.githubusercontent.com/96775/230469868-79f43a36-54b9-4215-a3cb-54c6eb8d6f03.png)

## Before these changes

![image](https://user-images.githubusercontent.com/96775/230465096-16c76f43-16ef-4309-a7fd-f9f823d68fa8.png)



# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

