### PR TITLE
Switch dataloads request to POST and update dataloads ID param

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -35,7 +35,8 @@ paths:
           in: path
           required: true
           schema:
-            $ref: '#/components/schemas/UUID'
+            type: string
+          description: The dataload_job_id for the job being updated
       requestBody:
         description: Data payload for job status
         content:

--- a/openapi.yml
+++ b/openapi.yml
@@ -14,7 +14,7 @@ paths:
         '200':
           description: The status of the service
   /v1/dataloads:
-    get:
+    post:
       summary: Retrieve the list of scheduled data loading jobs
       description: Provide a list of jobs to run since the last request
       responses:


### PR DESCRIPTION
# Why was this change made? 🤔

This is a small update to the openAPI spec to switch the API endpoint for schedule results from a GET to a POST since it requires a date and will update records, I believe a POST is the proper protocol to use.

This will unblock api ticket(s).

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

