### PR TITLE
Adds organization interface id to dataload_job.

### DIFF
--- a/app/models/dataload_job.rb
+++ b/app/models/dataload_job.rb
@@ -24,4 +24,5 @@ class DataloadJob < ApplicationRecord
   # file_pattern (optional): The filename pattern for airflow to use in order to find the correct vendor file
   # processing_tasks: Array of selected known data processing tasks.
   # log (large text field to capture any provided log data from airflow on failure)
+  # interface_id: The id of the interface in the organization.
 end

--- a/db/migrate/20230410144318_add_interface_to_dataload_job.rb
+++ b/db/migrate/20230410144318_add_interface_to_dataload_job.rb
@@ -1,0 +1,5 @@
+class AddInterfaceToDataloadJob < ActiveRecord::Migration[7.0]
+  def change
+    add_column :dataload_jobs, :interface_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_04_05_160735) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_10_144318) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -29,6 +29,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_04_05_160735) do
     t.text "log"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "interface_id"
     t.index ["vendor_id"], name: "index_dataload_jobs_on_vendor_id"
   end
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -52,6 +52,8 @@ components:
       properties:
         organizationId:
           $ref: '#/components/schemas/UUID'
+        interfaceId:
+          $ref: '#/components/schemas/UUID'
         dataLoadProfile:
           type: string
         dataProcessingSteps:


### PR DESCRIPTION
closesm #69

# Why was this change made? 🤔
The interface id is needed to be able to get the URL/credentials for retrieving data from vendors.


# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

