### PR TITLE
Be explicit about including the dataload_job id in the response payload

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -50,6 +50,9 @@ components:
       type: object
       additionalProperties: true
       properties:
+        id:
+          type: integer
+          description: The id of the dataload_job in order to allow for updates
         organization_folio_id:
           $ref: '#/components/schemas/UUID'
         interface_id:
@@ -73,6 +76,7 @@ components:
             type: string
           description: An array of email addresses to include in any notifications.
       required:
+        - id
         - organization_folio_id
         - dataload_profile_id
     DataLoadJobsResponse:


### PR DESCRIPTION
# Why was this change made? 🤔

This is a small change to explicitly document that the dataload job id is included in the response payload. It was included by default (due to additionalProperties being true) but we want to be clear in the generated API documentation.

# How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including data writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

